### PR TITLE
Corrigindo validação de role do usuário na autorização

### DIFF
--- a/listelab-contrato/Controllers/ControladorPadrao.cs
+++ b/listelab-contrato/Controllers/ControladorPadrao.cs
@@ -79,7 +79,7 @@ namespace listelab_contrato.Controllers
         /// <returns>Retorna objeto com resultado da requisição.</returns>
         [HttpPost]
         [Route("cadastre")]
-        [Authorize(Roles = "0,1")]
+        [Authorize(Roles = "Admin,Professor")]
         public ActionResult<DtoResultado<T>> Cadastre([FromBody] T questao)
         {
             try
@@ -100,7 +100,7 @@ namespace listelab_contrato.Controllers
         /// <returns>Retorna objeto com resultado da requisição.</returns>
         [HttpPost]
         [Route("atualize")]
-        [Authorize(Roles = "0,1")]
+        [Authorize(Roles = "Admin,Professor")]
         public ActionResult<DtoResultado<T>> Atualize([FromBody] T objeto)
         {
             try
@@ -120,7 +120,7 @@ namespace listelab_contrato.Controllers
         /// <param name="codigo">Código da questão discursiva que se deseja excluir.</param>
         /// <returns>Retorna objeto com resultado da requisição.</returns>
         [HttpDelete("{codigo}")]
-        [Authorize(Roles = "0,1")]
+        [Authorize(Roles = "Admin,Professor")]
         public ActionResult<DtoResultado<T>> Delete(int codigo)
         {
             try

--- a/listelab-contrato/Startup.cs
+++ b/listelab-contrato/Startup.cs
@@ -48,7 +48,7 @@ namespace listelab_contrato
             var corsBuilder = new CorsPolicyBuilder();
             corsBuilder.AllowAnyHeader();
             corsBuilder.AllowAnyMethod();
-            corsBuilder.AllowAnyOrigin(); // For anyone access.
+            corsBuilder.AllowAnyOrigin();
             corsBuilder.AllowCredentials();
 
             services.AddCors(options =>


### PR DESCRIPTION
Roles estavam como os valores dos enums (0, 1, 2) e precisavam ser o nome dos enums (Admin, Professor, Aluno).