### PR TITLE
Correção id null de questão quando cadastra lista

### DIFF
--- a/listelab-servico/Conversores/ConversorListaDeQuestoes.cs
+++ b/listelab-servico/Conversores/ConversorListaDeQuestoes.cs
@@ -1,6 +1,7 @@
 ﻿using ListElab.Dominio.Conceitos.ListaObj;
 using ListElab.Dominio.Dtos;
 using ListElab.Servico.Conversores.Interfaces;
+using System;
 using System.Linq;
 
 namespace ListElab.Servico.Conversores
@@ -39,6 +40,12 @@ namespace ListElab.Servico.Conversores
             if (dto != null)
             {
                 lista = new ListaQuestoes();
+
+                if (dto.Id != null && dto.Id != Guid.Empty)
+                {
+                    lista.Id = dto.Id;
+                }
+
                 lista.NivelDificuldade = dto.NivelDificuldade;
                 lista.Tags = dto.Tags;
                 lista.Usuario = dto.Usuario;

--- a/listelab-servico/Conversores/ConversorListaDeQuestoes.cs
+++ b/listelab-servico/Conversores/ConversorListaDeQuestoes.cs
@@ -39,7 +39,6 @@ namespace ListElab.Servico.Conversores
             if (dto != null)
             {
                 lista = new ListaQuestoes();
-                lista.Id = dto.Id;
                 lista.NivelDificuldade = dto.NivelDificuldade;
                 lista.Tags = dto.Tags;
                 lista.Usuario = dto.Usuario;

--- a/listelab-servico/Conversores/ConversorQuestaoDiscursiva.cs
+++ b/listelab-servico/Conversores/ConversorQuestaoDiscursiva.cs
@@ -2,6 +2,7 @@
 using ListElab.Dominio.Conceitos.RespostaObj;
 using ListElab.Dominio.Dtos;
 using ListElab.Servico.Conversores.Interfaces;
+using System;
 using System.Linq;
 
 namespace ListElab.Servico.Conversores
@@ -37,6 +38,12 @@ namespace ListElab.Servico.Conversores
             if (dto != null)
             {
                 questao = new Questao<Discursiva>();
+
+                if (dto.Id != null && dto.Id != Guid.Empty)
+                {
+                    questao.Id = dto.Id;
+                }
+
                 questao.NivelDificuldade = dto.NivelDificuldade;
                 questao.Tags = dto.Tags;
                 questao.TempoMaximoDeResposta = dto.TempoMaximoDeResposta;

--- a/listelab-servico/Conversores/ConversorQuestaoDiscursiva.cs
+++ b/listelab-servico/Conversores/ConversorQuestaoDiscursiva.cs
@@ -37,7 +37,6 @@ namespace ListElab.Servico.Conversores
             if (dto != null)
             {
                 questao = new Questao<Discursiva>();
-                questao.Id = dto.Id;
                 questao.NivelDificuldade = dto.NivelDificuldade;
                 questao.Tags = dto.Tags;
                 questao.TempoMaximoDeResposta = dto.TempoMaximoDeResposta;


### PR DESCRIPTION
Quando se cadastrava questões numa lista o id estava sendo persistido vazio.