### PR TITLE
Arrumando validação e teste

### DIFF
--- a/listaelab-testes/TestesValidador/TestesValidadorQuestaoDiscursiva.cs
+++ b/listaelab-testes/TestesValidador/TestesValidadorQuestaoDiscursiva.cs
@@ -1,10 +1,9 @@
-﻿using ListElab.Data.Repositorios;
+﻿using ListElab.Dominio.Conceitos.AreaDeConhecimentoObj;
+using ListElab.Dominio.Conceitos.DisciplinaObj;
 using ListElab.Dominio.Conceitos.QuestaoObj;
 using ListElab.Dominio.Conceitos.RespostaObj;
-using ListElab.Dominio.Conceitos.UsuarioObj;
 using ListElab.Dominio.Enumeradores;
 using ListElab.Servico.Validacoes;
-using Moq;
 using NUnit.Framework;
 using System.Collections.Generic;
 
@@ -89,18 +88,44 @@ namespace ListElab.Testes.TestesValidador
             ValideTeste(cenarioInvalido, questaoDiscursiva, _validador, "Informe um valor válido para nível de dificuldade");
         }
 
-        //[Test, Theory]
-        //public void TesteRegraAutorDaQuestaoExiste(bool autorExiste)
-        //{
-        //    var mock = new Mock<IRepositorio<Usuario>>();
+        [Test, Theory]
+        public void TesteRegraAreaDeConhecimentoFoiInformada(bool areaDoConhecimentoInformada, bool codigoInformado)
+        {
+            _validador.AssineRegraAreaDeConhecimentoFoiInformada();
 
-        //    mock.Setup(repo => repo.ItemExiste(x => x.Email == "saulo@ufg.br")).Returns(autorExiste);
+            var questaoDiscursiva = new Questao<Discursiva>();
 
-        //    var questaoDiscursiva = new Questao<Discursiva> { Usuario = "saulo@ufg.br" };
+            if (areaDoConhecimentoInformada)
+            {
+                questaoDiscursiva.AreaDeConhecimento = new AreaDeConhecimento();
+            }
 
-        //    _validador.AssineRegraAutorDaQuestaoExiste();
+            if (areaDoConhecimentoInformada && codigoInformado)
+            {
+                questaoDiscursiva.AreaDeConhecimento.Codigo = "100";
+            }
 
-        //    ValideTeste(!autorExiste, questaoDiscursiva, _validador, "O autor da questão não é um usuário válido");
-        //}
+            ValideTeste(!areaDoConhecimentoInformada || !codigoInformado, questaoDiscursiva, _validador, "Área de conhecimento não informada ou inválida.");
+        }
+
+        [Test, Theory]
+        public void TesteRegraDisciplinaFoiInformada(bool discipinaInformada, bool codigoInformado)
+        {
+            _validador.AssineRegraDisciplinaFoiInformada();
+
+            var questaoDiscursiva = new Questao<Discursiva>();
+
+            if (discipinaInformada)
+            {
+                questaoDiscursiva.Disciplina = new Disciplina();
+            }
+
+            if (discipinaInformada && codigoInformado)
+            {
+                questaoDiscursiva.Disciplina.Codigo = "100";
+            }
+
+            ValideTeste(!discipinaInformada || !codigoInformado, questaoDiscursiva, _validador, "Disciplina não informada ou inválida.");
+        }
     }
 }

--- a/listelab-servico/Validacoes/ValidacoesQuestaoDiscursiva.cs
+++ b/listelab-servico/Validacoes/ValidacoesQuestaoDiscursiva.cs
@@ -103,7 +103,6 @@ namespace ListElab.Servico.Validacoes
         {
             RuleFor(questao => questao.AreaDeConhecimento)
                 .Must(x => x != null && !string.IsNullOrEmpty(x.Codigo))
-                .When(x => objetoPersistido != null)
                 .WithMessage("Área de conhecimento não informada ou inválida.");
         }
 
@@ -118,7 +117,6 @@ namespace ListElab.Servico.Validacoes
         {
             RuleFor(questao => questao.Disciplina)
                 .Must(x => x != null && !string.IsNullOrEmpty(x.Codigo))
-                .When(x => objetoPersistido != null)
                 .WithMessage("Disciplina não informada ou inválida.");
         }
 


### PR DESCRIPTION
Atividade: [Tec][Api] Ajustar Área de Conhecimento e Disciplina para ser cadastrado no banco
Descrição: As validações de área de conhecimento e disciplina estavam validando somente se o objeto persistido fosse diferente de null, mas para essa validação não precisa desse item. Foi criado os testes dessas duas validações também.
Ação: Removido a condição do objeto persistido diferente de null e criado os testes de unidade.