### PR TITLE
Tratando objeto nulo

### DIFF
--- a/listelab-servico/Conversores/ConversorListaDeQuestoes.cs
+++ b/listelab-servico/Conversores/ConversorListaDeQuestoes.cs
@@ -31,8 +31,17 @@ namespace ListElab.Servico.Conversores
                 dto.Usuario = objeto.Usuario;
                 dto.Titulo = objeto.Titulo;
                 dto.ProntaParaAplicacao = objeto.ProntaParaAplicacao;
-                dto.AreaDeConhecimento = new DtoAreaDoConhecimento { Codigo = objeto.AreaDeConhecimento.Codigo, Descricao = objeto.AreaDeConhecimento.Descricao };
-                dto.Disciplina = new DtoDisciplina { Codigo = objeto.Disciplina.Codigo, Descricao = objeto.Disciplina.Descricao };
+
+                if (objeto.AreaDeConhecimento != null)
+                {
+                    dto.AreaDeConhecimento = new DtoAreaDoConhecimento { Codigo = objeto.AreaDeConhecimento.Codigo, Descricao = objeto.AreaDeConhecimento.Descricao };
+                }
+
+                if (objeto.Disciplina != null)
+                {
+                    dto.Disciplina = new DtoDisciplina { Codigo = objeto.Disciplina.Codigo, Descricao = objeto.Disciplina.Descricao };
+                }
+
                 dto.Discursivas = objeto.Discursivas.Select(x => conversorQuestoes.Converta(x)).ToList();
             }
 
@@ -58,8 +67,17 @@ namespace ListElab.Servico.Conversores
                 lista.Usuario = dto.Usuario;
                 lista.Titulo = dto.Titulo;
                 lista.ProntaParaAplicacao = lista.ProntaParaAplicacao;
-                lista.AreaDeConhecimento = RepositorioAreaDeConhecimento().ConsulteUm(x => x.Codigo == dto.AreaDeConhecimento.Codigo);
-                lista.Disciplina = RepositorioDisciplina().ConsulteUm(x => x.Codigo == dto.Disciplina.Codigo);
+
+                if (dto.AreaDeConhecimento != null)
+                {
+                    lista.AreaDeConhecimento = RepositorioAreaDeConhecimento().ConsulteUm(x => x.Codigo == dto.AreaDeConhecimento.Codigo);
+                }
+
+                if (dto.Disciplina != null)
+                {
+                    lista.Disciplina = RepositorioDisciplina().ConsulteUm(x => x.Codigo == dto.Disciplina.Codigo);
+                }
+
                 lista.Discursivas = dto.Discursivas.Select(x => conversorQuestoes.Converta(x)).ToList();
             }
 

--- a/listelab-servico/Conversores/ConversorQuestaoDiscursiva.cs
+++ b/listelab-servico/Conversores/ConversorQuestaoDiscursiva.cs
@@ -29,8 +29,17 @@ namespace ListElab.Servico.Conversores
                 dto.Tipo = objeto.Tipo;
                 dto.Usuario = objeto.Usuario;
                 dto.Enunciado = objeto.Enunciado;
-                dto.AreaDeConhecimento = new DtoAreaDoConhecimento { Codigo = objeto.AreaDeConhecimento.Codigo, Descricao = objeto.AreaDeConhecimento.Descricao };
-                dto.Disciplina = new DtoDisciplina { Codigo = objeto.Disciplina.Codigo, Descricao = objeto.Disciplina.Descricao };
+                
+                if (objeto.AreaDeConhecimento != null)
+                {
+                    dto.AreaDeConhecimento = new DtoAreaDoConhecimento { Codigo = objeto.AreaDeConhecimento.Codigo, Descricao = objeto.AreaDeConhecimento.Descricao };
+                }
+
+                if (objeto.Disciplina != null)
+                {
+                    dto.Disciplina = new DtoDisciplina { Codigo = objeto.Disciplina.Codigo, Descricao = objeto.Disciplina.Descricao };
+                }
+                
                 dto.RespostaEsperada = objeto.RespostaEsperada.PalavrasChaves.Select(x => new DtoPalavraChave { Descricao = x.Descricao, Peso = x.Peso }).ToList();
             }
 
@@ -56,8 +65,17 @@ namespace ListElab.Servico.Conversores
                 questao.Tipo = dto.Tipo;
                 questao.Usuario = dto.Usuario;
                 questao.Enunciado = dto.Enunciado;
-                questao.AreaDeConhecimento = RepositorioAreaDeConhecimento().ConsulteUm(x => x.Codigo == dto.AreaDeConhecimento.Codigo);
-                questao.Disciplina = RepositorioDisciplina().ConsulteUm(x => x.Codigo == dto.Disciplina.Codigo);
+
+                if (dto.AreaDeConhecimento != null)
+                {
+                    questao.AreaDeConhecimento = RepositorioAreaDeConhecimento().ConsulteUm(x => x.Codigo == dto.AreaDeConhecimento.Codigo);
+                }
+
+                if (dto.Disciplina != null)
+                {
+                    questao.Disciplina = RepositorioDisciplina().ConsulteUm(x => x.Codigo == dto.Disciplina.Codigo);
+                }
+
                 questao.RespostaEsperada = new Discursiva { PalavrasChaves = dto.RespostaEsperada.Select(x => new PalavraChave { Descricao = x.Descricao, Peso = x.Peso }).ToList() };
             }
 


### PR DESCRIPTION
Atividade: Hotfix, objeto nulo.
Descrição: Ao converter uma disciplina ou área de conhecimento pode acontecer do objeto ou dto virem nulo, assim lançando uma exceção. Por isso foi feito um tratamento de objeto nulo.