### PR TITLE
Hotfix: Bugs no cadastro de lista

### DIFF
--- a/listelab-servico/Conversores/ConversorListaDeQuestoes.cs
+++ b/listelab-servico/Conversores/ConversorListaDeQuestoes.cs
@@ -87,7 +87,7 @@ namespace ListElab.Servico.Conversores
                 lista.NivelDificuldade = nivelDificuldade == 0 ? 1 : nivelDificuldade;
                 lista.Usuario = dto.Usuario;
                 lista.Titulo = dto.Titulo;
-                lista.ProntaParaAplicacao = lista.ProntaParaAplicacao;
+                lista.ProntaParaAplicacao = dto.ProntaParaAplicacao;
                 lista.AreasDeConhecimento = areasDeConhecimento;
                 lista.TempoEsperadoResposta = questoesDiscursiva.Sum(x => x.Questao.TempoMaximoDeResposta) + questoesMultiplaEscolha.Sum(x => x.Questao.TempoMaximoDeResposta) + questoesAssociacaoColunas.Sum(x => x.Questao.TempoMaximoDeResposta);
                 lista.Tags = tags;

--- a/listelab-servico/Validacoes/ValidacoesListaQuestoes.cs
+++ b/listelab-servico/Validacoes/ValidacoesListaQuestoes.cs
@@ -36,7 +36,10 @@ namespace ListElab.Servico.Validacoes
         public void AssineRegraListaDeveTerQuestoes()
         {
             RuleFor(x => x.Id)
-                .Must((lista, id) => lista.QuestoesDiscursivas != null && lista.QuestoesDiscursivas.Count > 0)
+                .Must((lista, id) => (lista.QuestoesDiscursivas != null && lista.QuestoesDiscursivas.Count > 0) ||
+                                    (lista.QuestoesMultiplaEscolha != null && lista.QuestoesMultiplaEscolha.Count > 0) ||
+                                    (lista.QuestoesVerdadeiroOuFalso != null && lista.QuestoesVerdadeiroOuFalso.Count > 0) ||
+                                    (lista.QuestoesAssociacaoDeColunas != null && lista.QuestoesAssociacaoDeColunas.Count > 0))
                 .WithMessage("É preciso informar as questões que compõe uma lista, certifique-se de que os ids das questões foram repassados à requisição");
         }
 


### PR DESCRIPTION
1 - Não estava alterando a propriedade: ProntaParaSerAplicada
2 - Ele só considerava a lista de discursiva para validar se havia sido cadastrada questões na lista.